### PR TITLE
Updated Arch Linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ paru -S pcsx-redux-git
 Alternatively, the following steps describe how to install dependencies and compile manually:
 
 ```bash
-sudo pacman -S capstone clang git make pkg-config ffmpeg libuv zlib glfw-x11 curl xorg-server-xvfb
+sudo pacman -S --needed capstone clang git make pkg-config ffmpeg libuv zlib glfw-x11 curl xorg-server-xvfb imagemagick
 ```
 The mipsel environment can be installed from [AUR](https://wiki.archlinux.org/index.php/Aur) : [cross-mipsel-linux-gnu-binutils](https://aur.archlinux.org/packages/cross-mipsel-linux-gnu-binutils/) and [cross-mipsel-linux-gnu-gcc](https://aur.archlinux.org/packages/cross-mipsel-linux-gnu-gcc/) using your [AURhelper](https://wiki.archlinux.org/index.php/AUR_helpers) of choice:
 


### PR DESCRIPTION
ImageMagick is needed in order to use the 'convert' command.
Also the '--needed' flag will skip already installed packages.